### PR TITLE
Easy testing with vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ env
 *.pyc
 settings
 .#*
+.vagrant
+/src

--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ flask run
 flask import_users  #This actually will run map stats to get all users on the map
 flask import_alliances #Importing alliance from alliances.js file
 ```
+
+# Testing with Vagrant
+
+1. Install vagrant.
+2. Copy `provisioning/settings` to project root and add your screeps api credentials.
+3. Run `vagrant up` in the project root.
+4. Wait.
+5. Once complete open http://127.0.0.1:8080/ in a browser.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,14 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+
+  config.vm.box = "ubuntu/xenial64"
+  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.provision "shell", path: "provisioning/setup.sh"
+
+end

--- a/provisioning/nginx/screeps_loan
+++ b/provisioning/nginx/screeps_loan
@@ -1,0 +1,8 @@
+server {
+    listen 80;
+
+    location / {
+        include proxy_params;
+        proxy_pass http://unix:/tmp/screeps_loan.sock;
+    }
+}

--- a/provisioning/screeps_loan.service
+++ b/provisioning/screeps_loan.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Gunicorn instance to serve screeps_loan
+After=network.target
+
+[Service]
+User=ubuntu
+Group=ubuntu
+WorkingDirectory=/vagrant
+Environment="PATH=/vagrant/env/bin"
+Environment="SETTINGS=/vagrant/settings"
+Environment="FLASK_APP=/vagrant/screeps_loan/screeps_loan.py"
+ExecStart=/vagrant/env/bin/gunicorn --workers 3 --bind unix:/tmp/screeps_loan.sock -m 000 screeps_loan:app
+
+[Install]
+WantedBy=multi-user.target

--- a/provisioning/setup.sh
+++ b/provisioning/setup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+cd /vagrant
+
+apt-get update
+apt-get -f -y install git nano man
+apt-get -f -y install nginx
+apt-get -f -y install python3-pip python3-dev virtualenv
+apt-get -f -y install postgresql postgresql-contrib libpq-dev
+
+sudo -u postgres psql -c "CREATE USER screeps WITH PASSWORD 'screeps';"
+sudo -u postgres psql -c "create database \"screeps\" with owner \"screeps\" encoding='utf8' template template0"
+
+virtualenv -p /usr/bin/python3 env
+source env/bin/activate
+pip install -r requirements.txt
+mkdir /home/ubuntu/objects
+
+export SETTINGS=/vagrant/settings
+export FLASK_APP=/vagrant/screeps_loan/screeps_loan.py
+python db/manage.py version_control
+python db/manage.py upgrade
+flask import_users  #This actually will run map stats to get all users on the map
+flask import_alliances #Importing alliance from alliances.js file
+
+
+
+
+ln -s /vagrant/provisioning/screeps_loan.service /etc/systemd/system/screeps_loan.service
+ln -s /vagrant/provisioning/nginx/screeps_loan /etc/nginx/sites-enabled/screeps_loan
+rm /etc/nginx/sites-enabled/default
+
+
+systemctl start screeps_loan.service
+systemctl enable screeps_loan.service
+
+systemctl restart nginx.service
+systemctl enable nginx.service
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,12 +15,14 @@ pkg-resources==0.0.0
 psycopg2==2.6.2
 requests==2.11.1
 Requires==0.0.3
-screepsapi==0.2
+#screepsapi==0.2
+-e git+https://github.com/NhanHo/python-screeps.git@c9ef4d879f5b4d10f62eca9e824c38a16ab40978#egg=screepsapi
 six==1.10.0
 SQLAlchemy==1.0.15
 sqlalchemy-migrate==0.10.0
 sqlparse==0.2.1
 Tempita==0.5.2
+uWSGI==2.0.14
 webencodings==0.5
 websocket==0.2.1
 websocket-client==0.37.0


### PR DESCRIPTION
As the readme update says-

1. Install vagrant.
2. Copy `provisioning/settings` to project root and add your screeps api credentials.
3. Run `vagrant up` in the project root.
4. Wait.
5. Once complete open http://127.0.0.1:8080/ in a browser.