### PR TITLE
Hide alliances without any users from the alliances index screen.

### DIFF
--- a/screeps_loan/routes/alliances.py
+++ b/screeps_loan/routes/alliances.py
@@ -46,7 +46,8 @@ def alliance_listing():
         if not alliance['shortname']:
             continue
         alliance['users'] = [user for user in users_with_alliance if user['alliance'] == alliance['shortname']]
-        display_alliances.append(alliance)
+        if alliance['users']:
+            display_alliances.append(alliance)
     display_alliances = sorted(display_alliances, key=lambda k: k['fullname'])
     return render_template("alliance_listing.html", alliances = display_alliances)
 


### PR DESCRIPTION
This should, I think, hide all completely userless alliances completely.

I'm not sure if / when the application should remove such alliances from the database completely, but this at least clears up the interface.