### PR TITLE
Make screeps ID retrieval case insensitive

### DIFF
--- a/screeps_loan/models/users.py
+++ b/screeps_loan/models/users.py
@@ -26,7 +26,7 @@ def update_alliance_by_screeps_id(id, alliance):
 
 @cache.cache()
 def player_id_from_db(name):
-    query = "SELECT screeps_id FROM users WHERE ign=%s"
+    query = "SELECT screeps_id FROM users WHERE LOWER(ign)=LOWER(%s)"
     row = db.find_one(query, (name,))
     if (row is not None):
         return row[0]


### PR DESCRIPTION
This removes a ton of errors from the website when players happen to
get the wrong case on a username. This is particularly useful as it
appears the screeps API itself is now case insensitive on the username
too.