### PR TITLE
Enable CORS on select routes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Beaker==1.8.0
 click==6.6
 decorator==4.0.10
 Flask==0.11.1
+flask-cors==3.0.2
 gevent==1.1.2
 greenlet==0.4.10
 gunicorn==19.6.0

--- a/screeps_loan/routes/alliances.py
+++ b/screeps_loan/routes/alliances.py
@@ -9,7 +9,7 @@ from flask_cors import cross_origin
 
 
 @app.route('/alliances.js')
-@cross_origin()
+@cross_origin(origins="*", send_wildcard=True, methods="GET")
 def alliance_listing_json():
     import screeps_loan.models.alliances as alliances
     import screeps_loan.models.users as users
@@ -70,7 +70,7 @@ def alliance_profile(shortname):
     return render_template("alliance_profile.html", shortname = shortname, charter= charter, alliance=alliance);
 
 @app.route('/a/<shortname>.json')
-@cross_origin()
+@cross_origin(origins="*", send_wildcard=True, methods="GET")
 @httpresponse(expires=300, content_type='application/json')
 def alliance_profile_json(shortname):
     users = users_model.find_name_by_alliance(shortname)

--- a/screeps_loan/routes/alliances.py
+++ b/screeps_loan/routes/alliances.py
@@ -5,6 +5,7 @@ import screeps_loan.models.users as users_model
 from screeps_loan.routes.decorators import httpresponse
 import json
 from flask import render_template
+from flask_cors import cross_origin
 
 
 @app.route('/alliances.js')

--- a/screeps_loan/routes/alliances.py
+++ b/screeps_loan/routes/alliances.py
@@ -8,6 +8,7 @@ from flask import render_template
 
 
 @app.route('/alliances.js')
+@cross_origin()
 def alliance_listing_json():
     import screeps_loan.models.alliances as alliances
     import screeps_loan.models.users as users
@@ -68,6 +69,7 @@ def alliance_profile(shortname):
     return render_template("alliance_profile.html", shortname = shortname, charter= charter, alliance=alliance);
 
 @app.route('/a/<shortname>.json')
+@cross_origin()
 @httpresponse(expires=300, content_type='application/json')
 def alliance_profile_json(shortname):
     users = users_model.find_name_by_alliance(shortname)

--- a/screeps_loan/routes/map.py
+++ b/screeps_loan/routes/map.py
@@ -3,7 +3,7 @@ from screeps_loan.models.rooms import get_all_rooms
 from screeps_loan.routes.decorators import httpresponse
 import json
 from flask import render_template
-@cross_origin()
+from flask_cors import cross_origin
 
 @app.route('/map/rooms.js')
 @cross_origin()

--- a/screeps_loan/routes/map.py
+++ b/screeps_loan/routes/map.py
@@ -6,7 +6,7 @@ from flask import render_template
 from flask_cors import cross_origin
 
 @app.route('/map/rooms.js')
-@cross_origin()
+@cross_origin(origins="*", send_wildcard=True, methods="GET")
 @httpresponse(expires=300, content_type='application/json')
 def alliance_room_json():
     room_data = get_all_rooms()

--- a/screeps_loan/routes/map.py
+++ b/screeps_loan/routes/map.py
@@ -3,7 +3,7 @@ from screeps_loan.models.rooms import get_all_rooms
 from screeps_loan.routes.decorators import httpresponse
 import json
 from flask import render_template
-
+@cross_origin()
 
 @app.route('/map/rooms.js')
 @httpresponse(expires=300, content_type='application/json')

--- a/screeps_loan/routes/map.py
+++ b/screeps_loan/routes/map.py
@@ -6,6 +6,7 @@ from flask import render_template
 @cross_origin()
 
 @app.route('/map/rooms.js')
+@cross_origin()
 @httpresponse(expires=300, content_type='application/json')
 def alliance_room_json():
     room_data = get_all_rooms()

--- a/screeps_loan/screeps_loan.py
+++ b/screeps_loan/screeps_loan.py
@@ -13,6 +13,7 @@ import screeps_loan.routes.map
 import screeps_loan.routes.my_alliance
 
 @app.route('/obj/<filename>')
+@cross_origin()
 def get_obj(filename):
     return send_from_directory(app.config['OBJECT_STORAGE'], filename)
 

--- a/screeps_loan/screeps_loan.py
+++ b/screeps_loan/screeps_loan.py
@@ -14,7 +14,7 @@ import screeps_loan.routes.map
 import screeps_loan.routes.my_alliance
 
 @app.route('/obj/<filename>')
-@cross_origin()
+@cross_origin(origins="*", send_wildcard=True, methods="GET")
 def get_obj(filename):
     return send_from_directory(app.config['OBJECT_STORAGE'], filename)
 

--- a/screeps_loan/screeps_loan.py
+++ b/screeps_loan/screeps_loan.py
@@ -1,5 +1,6 @@
 from flask import Flask, session, redirect, url_for, escape, request, render_template, flash, send_from_directory
 from screeps_loan import app
+from flask_cors import cross_origin
 app.config.from_envvar('SETTINGS')
 
 import socket


### PR DESCRIPTION
Enabled CORS on the following routes: '/alliances.js', '/a/<shortname>.json', '/map/rooms.js' and
'/obj/<filename>'. CORS sends wildcard instead of echoing requestor's url in "Access-Control-Allow-Origin" to support caching by CDN.