### PR TITLE
Alliance Rankings Member Minimum

### DIFF
--- a/screeps_loan/cli/import_rankings.py
+++ b/screeps_loan/cli/import_rankings.py
@@ -79,7 +79,7 @@ class Rankings(object):
 
 
             # Not enough members.
-            if len(members) < 2:
+            if len(filtered_members) < 2:
                 continue
 
             # Not enough rooms


### PR DESCRIPTION
Alliances need at least two active members to appear on rankings