### PR TITLE
Filter map to show only active alliances

### DIFF
--- a/screeps_loan/models/users.py
+++ b/screeps_loan/models/users.py
@@ -1,6 +1,6 @@
 from screeps_loan.models import db
 from screeps_loan.services.cache import cache
-
+from screeps_loan.models.db import get_conn
 
 class UserQuery():
     def find_name_by_alliances(self, alliances):
@@ -55,6 +55,25 @@ def user_name_from_db_id(id):
         return row[0]
     return None
 
+
+@cache.cache()
+def get_player_room_count(player):
+    query = '''
+    SELECT COUNT(DISTINCT rooms.name)
+          FROM rooms,users
+          WHERE rooms.owner=users.id
+              AND users.ign=%s
+              AND rooms.import = (SELECT id
+                                      FROM room_imports
+                                      ORDER BY id desc
+                                      LIMIT 1
+                                  );
+    '''
+    conn = get_conn()
+    cursor = conn.cursor()
+    cursor.execute(query, (player,))
+    result = cursor.fetchone()
+    return int(result[0])
 
 
 

--- a/screeps_loan/routes/alliances.py
+++ b/screeps_loan/routes/alliances.py
@@ -30,7 +30,10 @@ def alliance_listing_json():
         alliance['members'] = [user['name'] for user in users_with_alliance
                                if user['alliance'] == alliance['shortname']]
 
-        if len(alliance['members']) < 2:
+
+        filtered_members = [user for user in alliance['members'] if users_model.get_player_room_count(user) > 0]
+
+        if len(filtered_members) < 2:
             continue
 
         if alliances_model.get_room_count(alliance['shortname']) < 2:


### PR DESCRIPTION
This change removes alliances with less than two active members from showing up in the map.