### PR TITLE
Implemented leaders for alliances

### DIFF
--- a/db/versions/012_Add_alliances_leaders_table_postgresql_downgrade.sql
+++ b/db/versions/012_Add_alliances_leaders_table_postgresql_downgrade.sql
@@ -1,0 +1,1 @@
+DROP TABLE alliances_leaders

--- a/db/versions/012_Add_alliances_leaders_table_postgresql_upgrade.sql
+++ b/db/versions/012_Add_alliances_leaders_table_postgresql_upgrade.sql
@@ -1,0 +1,5 @@
+CREATE TABLE alliances_leaders (
+alliance character varying(255),
+user_id integer NOT NULL,
+PRIMARY KEY(alliance, user_id)
+);

--- a/db/versions/012_Add_alliances_leaders_table_postgresql_upgrade.sql
+++ b/db/versions/012_Add_alliances_leaders_table_postgresql_upgrade.sql
@@ -1,5 +1,4 @@
 CREATE TABLE alliances_leaders (
-alliance character varying(255),
-user_id integer NOT NULL,
-PRIMARY KEY(alliance, user_id)
+user_id integer PRIMARY KEY,
+alliance character varying(255)
 );

--- a/screeps_loan/cli/manage.py
+++ b/screeps_loan/cli/manage.py
@@ -1,6 +1,7 @@
 import click
 from screeps_loan import app
 from screeps_loan.models import users
+import screeps_loan.models.alliances_leaders as alliances_leaders_model
 import screeps_loan.screeps_client as screeps_client
 from screeps_loan.auth_user import AuthPlayer
 
@@ -32,3 +33,28 @@ def login_as_user(user):
 @click.argument('alliance')
 def room_count(alliance):
     click.echo(alliances_model.get_room_count(alliance))
+
+
+@app.cli.command()
+@click.argument('alliance')
+@click.argument('user')
+def remove_alliance_leader(alliance, user):
+    user_id = users.user_id_from_db(user)
+    if user_id:
+        alliances_leaders_model.remove_leader(alliance, user_id)
+    else:
+        click.echo('user not found')
+
+@app.cli.command()
+@click.argument('alliance')
+@click.argument('user')
+def add_alliance_leader(alliance, user):
+    user_id = users.user_id_from_db(user)
+    if user_id:
+        alliance = alliances_model.find_by_shortname(alliance)
+        if alliance:
+            alliances_leaders_model.add_leader(alliance, user_id)
+        else:
+            click.echo('alliance not found')
+    else:
+        click.echo('user not found')

--- a/screeps_loan/models/alliances_leaders.py
+++ b/screeps_loan/models/alliances_leaders.py
@@ -1,0 +1,15 @@
+from screeps_loan.models import db
+from screeps_loan.services.cache import cache
+
+
+def add_leader(alliance, user_id):
+    query = "INSERT INTO alliances_leaders (alliance, user_id) VALUES (%s, %s)"
+    db.execute(query, (alliance, user_id))
+
+def remove_leader(alliance, user_id):
+    query = "DELETE FROM alliances_leaders WHERE alliance= %s AND user_id= %s"
+    db.execute(query, (alliance, user_id))
+
+def get_leaders(alliance):
+    query = "SELECT users.ign FROM alliances_leaders INNER JOIN users ON users.id = alliances_leaders.user_id WHERE alliances_leaders.alliance= %s"
+    return db.find_all(query, (alliance,))

--- a/screeps_loan/models/alliances_leaders.py
+++ b/screeps_loan/models/alliances_leaders.py
@@ -10,6 +10,10 @@ def remove_leader(alliance, user_id):
     query = "DELETE FROM alliances_leaders WHERE alliance= %s AND user_id= %s"
     db.execute(query, (alliance, user_id))
 
+def remove_by_user_id(user_id):
+    query = "DELETE FROM alliances_leaders WHERE user_id= %s"
+    db.execute(query, (user_id, ))
+
 def get_leaders(alliance):
     query = "SELECT users.ign FROM alliances_leaders INNER JOIN users ON users.id = alliances_leaders.user_id WHERE alliances_leaders.alliance= %s"
     result = db.find_all(query, (alliance,))

--- a/screeps_loan/models/alliances_leaders.py
+++ b/screeps_loan/models/alliances_leaders.py
@@ -12,4 +12,5 @@ def remove_leader(alliance, user_id):
 
 def get_leaders(alliance):
     query = "SELECT users.ign FROM alliances_leaders INNER JOIN users ON users.id = alliances_leaders.user_id WHERE alliances_leaders.alliance= %s"
-    return db.find_all(query, (alliance,))
+    result = db.find_all(query, (alliance,))
+    return [row[0] for row in result]

--- a/screeps_loan/routes/my_alliance.py
+++ b/screeps_loan/routes/my_alliance.py
@@ -111,6 +111,7 @@ def create_an_alliance():
 @login_required
 def leave_alliance():
     users_model.update_alliance_by_screeps_id(session['screeps_id'], None)
+    alliances_leaders_model.remove_by_user_id(session['my_id'])
     return redirect(url_for("my_alliance"))
 
 

--- a/screeps_loan/routes/my_alliance.py
+++ b/screeps_loan/routes/my_alliance.py
@@ -6,6 +6,7 @@ import hashlib
 import screeps_loan.models.alliances as alliances_model
 import screeps_loan.models.invites as invites
 import screeps_loan.models.users as users_model
+import screeps_loan.models.alliances_leaders as alliances_leaders_model
 from screeps_loan.routes.decorators import login_required
 from screeps_loan.auth_user import AuthPlayer
 import screeps_loan.services.users as users_service
@@ -85,7 +86,9 @@ def my_alliance():
     alliance = users_model.alliance_of_user(my_id)
     if (alliance is None):
         return render_template("alliance_creation.html")
-    return render_template('my.html', alliance = alliance)
+
+    leaders = alliances_leaders_model.get_leaders(alliance[1])
+    return render_template('my.html', alliance=alliance,leaders=leaders)
 
 
 @app.route('/my/create', methods=["POST"])

--- a/screeps_loan/routes/my_alliance.py
+++ b/screeps_loan/routes/my_alliance.py
@@ -192,6 +192,9 @@ def kick_from_alliance(username):
 
     users_model.update_alliance_by_user_id(user_id, None)
 
+    if username in leaders:
+        alliances_leaders_model.remove_leader(alliance[1], user_id)
+
     flash('Successfully kicked user from your alliance')
     return redirect(url_for("my_alliance"))
 

--- a/screeps_loan/routes/my_alliance.py
+++ b/screeps_loan/routes/my_alliance.py
@@ -88,7 +88,8 @@ def my_alliance():
         return render_template("alliance_creation.html")
 
     leaders = alliances_leaders_model.get_leaders(alliance[1])
-    return render_template('my.html', alliance=alliance,leaders=leaders)
+    members = users_model.find_name_by_alliance(alliance[1])
+    return render_template('my.html', alliance=alliance,leaders=leaders,users=members)
 
 
 @app.route('/my/create', methods=["POST"])
@@ -157,9 +158,9 @@ def invite_to_alliance():
 
 
 
-@app.route('/kick', methods=["POST"])
+@app.route('/kick/<username>')
 @login_required
-def kick_from_alliance():
+def kick_from_alliance(username):
 
     my_id = session['my_id']
     alliance = users_model.alliance_of_user(my_id)
@@ -170,8 +171,6 @@ def kick_from_alliance():
 
     if alliance is None:
         return "You are not in an alliance, can't kick anyone"
-
-    username = request.form['username']
 
     # Get database id
     user_id = users_model.user_id_from_db(username)

--- a/screeps_loan/routes/my_alliance.py
+++ b/screeps_loan/routes/my_alliance.py
@@ -104,6 +104,7 @@ def create_an_alliance():
         shortname = re.sub(r'\w+', '', request.form['shortname'])
 
     alliances_model.create_an_alliance(my_id, fullname, shortname)
+    alliances_leaders_model.add_leader(shortname, my_id)
     return redirect(url_for("my_alliance"))
 
 

--- a/screeps_loan/routes/my_alliance.py
+++ b/screeps_loan/routes/my_alliance.py
@@ -188,3 +188,14 @@ def kick_from_alliance():
 
     flash('Successfully kicked user from your alliance')
     return redirect(url_for("my_alliance"))
+
+
+@app.route('/claim-leader')
+@login_required
+def claim_leader():
+    alliance = users_model.alliance_of_user(session['my_id'])
+    leaders = alliances_leaders_model.get_leaders(alliance[1])
+    if leaders is not None:
+        alliances_leaders_model.add_leader(alliance[1], session['my_id'])
+        flash('You are now leader of '+alliance[1])
+    return redirect(url_for("my_alliance"))

--- a/screeps_loan/routes/my_alliance.py
+++ b/screeps_loan/routes/my_alliance.py
@@ -163,6 +163,11 @@ def kick_from_alliance():
 
     my_id = session['my_id']
     alliance = users_model.alliance_of_user(my_id)
+    leaders = alliances_leaders_model.get_leaders(alliance[1])
+    if session['username'] not in leaders:
+        flash('You are not a alliance leader, can\'t kick anyone')
+        return redirect(url_for("my_alliance"))
+
     if alliance is None:
         return "You are not in an alliance, can't kick anyone"
 

--- a/screeps_loan/routes/my_alliance.py
+++ b/screeps_loan/routes/my_alliance.py
@@ -160,9 +160,9 @@ def invite_to_alliance():
 
 
 
-@app.route('/kick/<username>')
+@app.route('/kick', methods=["POST"])
 @login_required
-def kick_from_alliance(username):
+def kick_from_alliance():
 
     my_id = session['my_id']
     alliance = users_model.alliance_of_user(my_id)
@@ -173,6 +173,8 @@ def kick_from_alliance(username):
 
     if alliance is None:
         return "You are not in an alliance, can't kick anyone"
+
+    username = request.form['username']
 
     # Get database id
     user_id = users_model.user_id_from_db(username)

--- a/screeps_loan/templates/my.html
+++ b/screeps_loan/templates/my.html
@@ -29,6 +29,10 @@
         </ul>
         <div class="tabs-content" data-tabs-content="example-tabs">
             <div class="tabs-panel is-active" id="panel1">
+                {% if not leaders %}
+                    You're alliance does not have a leader yet, click <a href="/claim-leader">here</a> to claim leadership <br>
+                    <hr>
+                {% endif %}
                 <form action="/invite" method="POST">
                     <p> Invite a user to your alliance. NAME IS CASE SENSITIVE</p>
                     <p><input type=text name=username></p>

--- a/screeps_loan/templates/my.html
+++ b/screeps_loan/templates/my.html
@@ -42,7 +42,10 @@
                     <tr>
                         <td style="width: 1px; white-space: nowrap;">
                             {% if session['username'] in leaders %}
-                                <a href="/kick/{{ user }}" onclick="return confirm('Are you sure you want to remove {{user}} from your alliance?')"><i class="fa fa-minus-circle" style="color:black"></i></a>
+                                <form method="POST" action="/kick">
+                                    <input type="hidden" name="username" value="{{user}}">
+                                    <a href="#" onclick="return confirm('Are you sure you want to remove {{user}} from your alliance?') && this.parentElement.submit();"><i class="fa fa-minus-circle" style="color:black"></i></a>
+                                </form>
                             {% endif %}
                         </td>
                         <td><a href="https://screeps.com/a/#!/profile/{{user}}" target="_blank">{{ user }}</a></td>

--- a/screeps_loan/templates/my.html
+++ b/screeps_loan/templates/my.html
@@ -23,9 +23,10 @@
                  src="{{url_for('static', filename = 'img/leaguelogo.png') }}">
             {% endif %}
             </div>
-            <li class="tabs-title is-active"><a href="#panel1" aria-selected="true">Management</a></li>
-            <li class="tabs-title"><a href="#panel2" onclick="activateCharterBox()">Charter</a></li>
-            <li class="tabs-title"><a href="#panel3">Leave Alliance</a></li>
+            <li class="tabs-title is-active"><a href="#panel1" aria-selected="true">Members</a></li>
+            <li class="tabs-title"><a href="#panel2">Management</a></li>
+            <li class="tabs-title"><a href="#panel3" onclick="activateCharterBox()">Charter</a></li>
+            <li class="tabs-title"><a href="#panel4">Leave Alliance</a></li>
         </ul>
         <div class="tabs-content" data-tabs-content="example-tabs">
             <div class="tabs-panel is-active" id="panel1">
@@ -33,20 +34,30 @@
                     You're alliance does not have a leader yet, click <a href="/claim-leader">here</a> to claim leadership <br>
                     <hr>
                 {% endif %}
+                <table class="table">
+                    <tr>
+                        <th colspan="2" class="members-table-header">Name</th>
+                    </tr>
+                    {% for user in users %}
+                    <tr>
+                        <td style="width: 1px; white-space: nowrap;">
+                            {% if session['username'] in leaders %}
+                                <a href="/kick/{{ user }}" onclick="return confirm('Are you sure you want to remove {{user}} from your alliance?')"><i class="fa fa-minus-circle" style="color:black"></i></a>
+                            {% endif %}
+                        </td>
+                        <td><a href="https://screeps.com/a/#!/profile/{{user}}" target="_blank">{{ user }}</a></td>
+                    </tr>
+                    {% endfor %}
+                </table>
+                <hr>
                 <form action="/invite" method="POST">
                     <p> Invite a user to your alliance. NAME IS CASE SENSITIVE</p>
                     <p><input type=text name=username></p>
                     <p><input class="button" type=submit value=Submit></p>
                 </form>
                 <hr>
-                {% if session['username'] in leaders %}
-                <form action="/kick" method="POST">
-                    <p> Remove a user from your alliance. NAME IS CASE SENSITIVE</p>
-                    <p><input type=text name=username></p>
-                    <p><input class="button" type=submit value=Submit></p>
-                </form>
-                <hr>
-                {% endif %}
+            </div>
+            <div class="tabs-panel" id="panel2">
                 Upload your logo (around 190x190)
                 <form enctype="multipart/form-data"
                       action="{{url_for('upload_my_alliance_logo')}}" method="POST">
@@ -96,13 +107,13 @@
                 </form>
 
             </div>
-            <div class="tabs-panel" id="panel2">
+            <div class="tabs-panel" id="panel3">
                 <form id="charter-form" action="/my/updatecharter" method="POST">
                     <textarea id="charter" name="charter">{{alliance['charter']}}</textarea>
                     <input type=submit value="Submit">
                 </form>
             </div>
-            <div class="tabs-panel" id="panel3">
+            <div class="tabs-panel" id="panel4">
                 <form id="leave-form" action="/my/leave" method="POST">
                     <input class="button" type=submit value="Leave Alliance">
                 </form>

--- a/screeps_loan/templates/my.html
+++ b/screeps_loan/templates/my.html
@@ -39,12 +39,14 @@
                     <p><input class="button" type=submit value=Submit></p>
                 </form>
                 <hr>
+                {% if session['username'] in leaders %}
                 <form action="/kick" method="POST">
                     <p> Remove a user from your alliance. NAME IS CASE SENSITIVE</p>
                     <p><input type=text name=username></p>
                     <p><input class="button" type=submit value=Submit></p>
                 </form>
                 <hr>
+                {% endif %}
                 Upload your logo (around 190x190)
                 <form enctype="multipart/form-data"
                       action="{{url_for('upload_my_alliance_logo')}}" method="POST">


### PR DESCRIPTION
Made a separate table for storing leaders. Migration file and CLI methods for managing leaders are included.

When a alliance has no leader, a link will be shown to claim leadership. At the moment only a single leader is supported.