### PR TITLE
Make the latest DB changes into actual migrations

### DIFF
--- a/db/versions/001_Add_initial_tables_postgresql_upgrade.sql
+++ b/db/versions/001_Add_initial_tables_postgresql_upgrade.sql
@@ -1,6 +1,6 @@
 CREATE TABLE alliances (
     shortname character varying(255) NOT NULL,
-    discord_url character varying(2044),
+    slack_channel character varying(2044),
     fullname character varying(2044),
     color character varying(15)
 );

--- a/db/versions/006_rankings_postgresql_upgrade.sql
+++ b/db/versions/006_rankings_postgresql_upgrade.sql
@@ -1,7 +1,7 @@
 CREATE TABLE rankings_imports (
-  id integer NOT NULL,
-  started_at timestamp without time zone default current_timestamp,
-  status character varying(50) NOT NULL
+    id integer NOT NULL,
+    started_at timestamp without time zone default current_timestamp,
+    status character varying(50) NOT NULL
 );
 
 CREATE SEQUENCE rankings_imports_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
@@ -9,29 +9,28 @@ CREATE SEQUENCE rankings_imports_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE 
 ALTER SEQUENCE rankings_imports_id_seq OWNED BY rankings_imports.id;
 
 ALTER TABLE
-  ONLY rankings_imports
+    ONLY rankings_imports
 ALTER COLUMN
-  id
+    id
 SET
-  DEFAULT nextval('rankings_imports_id_seq' :: regclass);
+    DEFAULT nextval('rankings_imports_id_seq' :: regclass);
 
 ALTER TABLE
-  ONLY rankings_imports
+    ONLY rankings_imports
 ADD
-  CONSTRAINT rankings_imports_pkey PRIMARY KEY (id);
+    CONSTRAINT rankings_imports_pkey PRIMARY KEY (id);
 
 CREATE TABLE rankings (
-  alliance character varying(255) NOT NULL,
-  import integer NOT NULL,
-  alliance_gcl integer NOT NULL,
-  combined_gcl integer NOT NULL,
-  average_gcl integer NOT NULL,
-  rcl integer NOT NULL,
-  spawns integer NOT NULL,
-  members integer NOT NULL
+    alliance character varying(255) NOT NULL,
+    import integer NOT NULL,
+    alliance_gcl integer NOT NULL,
+    combined_gcl integer NOT NULL,
+    rcl integer NOT NULL,
+    spawns integer NOT NULL,
+    members integer NOT NULL
 );
 
 ALTER TABLE
-  ONLY rankings
+    ONLY rankings
 ADD
-  CONSTRAINT rankings_pkey PRIMARY KEY (alliance, import);
+    CONSTRAINT rankings_pkey PRIMARY KEY (alliance, import);

--- a/db/versions/011_user_rankings_postgresql_downgrade.sql
+++ b/db/versions/011_user_rankings_postgresql_downgrade.sql
@@ -1,0 +1,6 @@
+# Remove new columns for user rankings
+ALTER TABLE
+    users DROP COLUMN gcl;
+
+ALTER TABLE
+    users DROP COLUMN power;

--- a/db/versions/011_user_rankings_postgresql_upgrade.sql
+++ b/db/versions/011_user_rankings_postgresql_upgrade.sql
@@ -1,11 +1,8 @@
-# Add new column for `shard` on `rooms`
+# Add new columns for user rankings
 ALTER TABLE
     users
 ADD
     COLUMN gcl bigint;
-    COLUMN gcl_level bigint;
-    COLUMN combined_rcl bigint;
-    COLUMN spawnCount bigint;
 
 ALTER TABLE
     users

--- a/db/versions/012_change_discord_url_postgresql_downgrade.sql
+++ b/db/versions/012_change_discord_url_postgresql_downgrade.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    alliances RENAME COLUMN discord_url TO slack_channel;

--- a/db/versions/012_change_discord_url_postgresql_upgrade.sql
+++ b/db/versions/012_change_discord_url_postgresql_upgrade.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    alliances RENAME COLUMN slack_channel TO discord_url;

--- a/db/versions/013_more_alliance_stats_postgresql_downgrade.sql
+++ b/db/versions/013_more_alliance_stats_postgresql_downgrade.sql
@@ -1,0 +1,7 @@
+ALTER TABLE
+    rankings DROP COLUMN average_gcl;
+
+ALTER TABLE
+    users DROP COLUMN gcl_level,
+    DROP COLUMN combined_rcl,
+    DROP COLUMN spawnCount;

--- a/db/versions/013_more_alliance_stats_postgresql_upgrade.sql
+++ b/db/versions/013_more_alliance_stats_postgresql_upgrade.sql
@@ -1,0 +1,13 @@
+ALTER TABLE
+    rankings
+ADD
+    average_gcl integer NOT NULL;
+
+ALTER TABLE
+    users
+ADD
+    COLUMN gcl_level bigint,
+ADD
+    COLUMN combined_rcl bigint,
+ADD
+    COLUMN spawnCount bigint;


### PR DESCRIPTION
That splits out the changes into their own migrations instead of editing history, which IMO feels a bit safer.

I found a somewhat related issue in that the postgres image doesn't create the screeps database, so from a blank slate you'll error when running `python db/manage.py version_control`. The fix for that is to do this:
```sh
docker compose exec postgres bash
su postgres
createdb -U screeps screeps
```