### PR TITLE
Initial alliance leadership rework

### DIFF
--- a/db/versions/014_Add_leader_column_postgresql_upgrade.sql
+++ b/db/versions/014_Add_leader_column_postgresql_upgrade.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    "alliances"
+ADD
+    COLUMN "leaders" integer [] DEFAULT '{0}';

--- a/screeps_loan/models/alliances.py
+++ b/screeps_loan/models/alliances.py
@@ -94,6 +94,11 @@ def update_charter_of_alliance(shortname, charter):
     db.execute(query, (charter, shortname))
 
 
+def update_leader_of_alliance(shortname, leaders):
+    query = "UPDATE alliances SET leaders=%s WHERE shortname = %s"
+    db.execute(query, (leaders, shortname))
+
+
 def update_all_alliances_info(
     shortname, new_shortname, fullname, discord_url, color="#000000"
 ):

--- a/screeps_loan/models/users.py
+++ b/screeps_loan/models/users.py
@@ -36,6 +36,12 @@ def find_users_by_alliance(alliance):
     ]
 
 
+def find_player_id_by_alliance(alliance):
+    query = "SELECT screeps_id FROM users where alliance = %s"
+    result = db.find_all(query, (alliance,))
+    return [row[0] for row in result]
+
+
 def update_alliance_by_screeps_id(id, alliance):
     query = "UPDATE users SET alliance = %s WHERE screeps_id=%s"
     db.execute(query, (alliance, id))
@@ -138,7 +144,7 @@ def insert_username_with_id(name, id):
 
 
 def alliance_of_user(id):
-    query = """SELECT fullname, shortname, logo, charter, discord_url, color
+    query = """SELECT fullname, shortname, logo, charter, discord_url, color, leaders
                 from users JOIN alliances ON alliance=shortname where id=%s"""
     return db.find_one(query, (id,))
 

--- a/screeps_loan/templates/my.html
+++ b/screeps_loan/templates/my.html
@@ -21,21 +21,17 @@
                 <img class="" src="{{url_for('static', filename = 'img/leaguelogo.png') }}">
                 {% endif %}
             </div>
-            <li class="tabs-title is-active"><a href="#panel1" aria-selected="true">Management</a></li>
+            <li class="tabs-title is-active"><a href="#panel1" aria-selected="true">Alliance Details</a></li>
+            <li class="tabs-title"><a href="#panel4">Members</a></li>
             <li class="tabs-title"><a href="#panel2" onclick="activateCharterBox()">Charter</a></li>
             <li class="tabs-title"><a href="#panel3">Leave Alliance</a></li>
+            <li class="tabs-title"><a href="#panel5" onclick="activateMessageBox()">Send Alliance Message</a></li>
         </ul>
         <div class="tabs-content" data-tabs-content="example-tabs">
             <div class="tabs-panel is-active" id="panel1">
-                <form action="/invite" method="POST">
-                    <p> Invite a user to your alliance. NAME IS CASE SENSITIVE</p>
-                    <p><input type=text name=username></p>
-                    <p><input class="button" type=submit value=Submit></p>
-                </form>
-                <hr>
-                <form action="/kick" method="POST">
-                    <p> Remove a user from your alliance. NAME IS CASE SENSITIVE</p>
-                    <p><input type=text name=username></p>
+                <form action="/updateleader" method="POST">
+                    <p> Set the leader of this alliance. NAME IS CASE SENSITIVE</p>
+                    <p><input type=text name=leader></p>
                     <p><input class="button" type=submit value=Submit></p>
                 </form>
                 <hr>
@@ -44,7 +40,6 @@
                     <input class="button" type=file name="logo">
                     <input class="button" type=submit value=Submit>
                 </form>
-
                 <hr>
                 <form action="/my/updateprofile" method="POST">
                     <div class="row">
@@ -96,21 +91,41 @@
                     <input class="button" type=submit value="Leave Alliance">
                 </form>
             </div>
+            <div class="tabs-panel" id="panel4">
+                <form id="invite-form" action="/invite" method="POST">
+                    <p> Invite a user to your alliance. NAME IS CASE SENSITIVE</p>
+                    <p><input type=text name=username></p>
+                    <p><input class="button" type=submit value=Submit></p>
+                </form>
+                <hr>
+                <form id="kick-form" action="/kick" method="POST">
+                    <p> Remove a user from your alliance. NAME IS CASE SENSITIVE (Leader Restricted)</p>
+                    <p><input type=text name=username></p>
+                    <p><input class="button" type=submit value=Submit></p>
+                </form>
+            </div>
+            <div class="tabs-panel" id="panel5">
+                <form id="alliance-message-form" action="/my/sendmessage" method="POST">
+                    <textarea id="alliance-message" name="alliance-message"></textarea>
+                    <input type=submit value="Submit">
+                </form>
+            </div>
         </div>
     </div>
-    {% endblock %}
-    {% block script %}
-    $(document).ready(function() {
+{% endblock %}
+
+{% block script %}
+$(document).ready(function() {
     //$("#colorpicker").spectrum({
-    // color: "#f00"
+    //    color: "#f00"
     //});
     var simplemde = new SimpleMDE({ element: document.getElementById("charter"),
-    autofocus:true});
-    function activateCharterBox() {
-    setTimeout(function() {
-    simplemde.codemirror.refresh();
-    }.bind(simplemde), 0);
+                                    autofocus:true});
+    function activateMessageBox() {
+        setTimeout(function() {
+            simplemde.codemirror.refresh();
+        }.bind(simplemde), 0);
     };
 
-    });
-    {% endblock %}
+});
+{% endblock %}


### PR DESCRIPTION
Only leaders can kick members
Leaders can be changed by the leader
Alliance initially does not have a leader set, so everyone can claim leadership
Restrict functions to leaders
Add ability to send alliance wide messages